### PR TITLE
fix: replace <cmath> with <math.h> in CUDA kernels and remove throws from extern "C" float4 launchers (C4297)

### DIFF
--- a/src/kernels/add/add_launcher.cu
+++ b/src/kernels/add/add_launcher.cu
@@ -189,7 +189,12 @@ extern "C" float run_add_shared(const float* a, const float* b, float* c, int N)
  */
 extern "C" float run_add_float4(const float* a, const float* b, float* c, int N)
 {
-   
+    if (N % 4 != 0)
+    {
+        std::cerr << "Error: N must be divisible by 4 for float4 kernel (got " << N << ")\n";
+        return -1.0f;
+    }
+
     int N_vec4 = N / 4;
 
     auto h_a4 = pack_and_pad_to_float4(a, N);
@@ -211,10 +216,12 @@ extern "C" float run_add_float4(const float* a, const float* b, float* c, int N)
         int passes = get_benchmark_passes();
 
         time_ms = benchmark_kernel(
-            [&]() { add_float4_kernel<<<config.blocks_per_grid, config.threads_per_block>>>(d_a4, d_b4, d_c4, N_vec4); },
+            [&]()
+            {
+                add_float4_kernel<<<config.blocks_per_grid, config.threads_per_block>>>(d_a4, d_b4, d_c4, N_vec4);
+            },
             warmup, passes);
 
-        // Copy results back to host and free device memory
         copy_from_device_and_free_float4(c, d_c4, d_a4, d_b4, N_vec4);
     }
     catch (const std::exception& e)

--- a/src/kernels/sin_cos_pow_relu/sin_cos_pow_relu_kernels.cu
+++ b/src/kernels/sin_cos_pow_relu/sin_cos_pow_relu_kernels.cu
@@ -8,7 +8,7 @@
  * including global memory, shared memory, and float4 vectorized variants.
  */
 
-#include <cmath>
+#include <math.h>
 
 #include "sin_cos_pow_relu_kernels.cuh"
 

--- a/src/kernels/sin_cos_pow_relu/sin_cos_pow_relu_launcher.cu
+++ b/src/kernels/sin_cos_pow_relu/sin_cos_pow_relu_launcher.cu
@@ -226,7 +226,8 @@ extern "C" float run_sin_cos_pow_relu_float4(const float* a, const float* b, flo
 {
     if (N % 4 != 0)
     {
-        throw std::invalid_argument("Input size N must be divisible by 4 for float4 kernel.");
+        std::cerr << "Error: N must be divisible by 4 for float4 kernel (got " << N << ")\n";
+        return -1.0f;
     }
 
     int N_vec4 = N / 4;

--- a/src/kernels/sqrt_log/sqrt_log_launcher.cu
+++ b/src/kernels/sqrt_log/sqrt_log_launcher.cu
@@ -235,7 +235,8 @@ extern "C" float run_sqrt_log_float4(const float* a, const float* b, float* c, i
 {
     if (N % 4 != 0)
     {
-        throw std::invalid_argument("Input size N must be divisible by 4 for float4 kernel.");
+        std::cerr << "Error: N must be divisible by 4 for float4 kernel (got " << N << ")\n";
+        return -1.0f;
     }
 
     int N_vec4 = N / 4;
@@ -258,7 +259,10 @@ extern "C" float run_sqrt_log_float4(const float* a, const float* b, float* c, i
         int passes = get_benchmark_passes();
 
         time_ms = benchmark_kernel(
-            [&]() { sqrt_log_float4_kernel<<<config.blocks_per_grid, config.threads_per_block>>>(d_a4, d_b4, d_c4, N_vec4); },
+            [&]()
+            {
+                sqrt_log_float4_kernel<<<config.blocks_per_grid, config.threads_per_block>>>(d_a4, d_b4, d_c4, N_vec4);
+            },
             warmup, passes);
 
         copy_from_device_and_free_float4(c, d_c4, d_a4, d_b4, N_vec4);


### PR DESCRIPTION
fix: replace <cmath> with <math.h> in CUDA kernels and remove throws from extern "C" float4 launchers (C4297)